### PR TITLE
Add UK to top-level and rationalize metadata between UM sims in UK/online

### DIFF
--- a/catalog.yaml
+++ b/catalog.yaml
@@ -19,4 +19,9 @@ sources:
     driver: yaml_file_cat
     args:
         path: "{{CATALOG_DIR}}/online/main.yaml"
+  UK:
+    description: online data sources
+    driver: yaml_file_cat
+    args:
+        path: "{{CATALOG_DIR}}/UK/main.yaml"
 

--- a/online/main.yaml
+++ b/online/main.yaml
@@ -100,41 +100,6 @@ sources:
       simulation_id: d3hp003
       time_start: 2020-01-01T00:00:00
       time_end: 2021-03-01T00:00:00
-  um_glm_n2560_RAL3p3:
-    args:
-      chunks: null
-      consolidated: true
-      urlpath: https://hackathon-o.s3-ext.jc.rl.ac.uk/sim-data/dev/v5/glm.n2560_RAL3p3/um.{{ time }}.hp_z{{ zoom }}.zarr
-    driver: zarr
-    parameters:
-      time:
-        allowed:
-        - PT1H
-        - PT3H
-        default: PT1H
-        description: time resolution of the dataset
-        type: str
-      zoom:
-        allowed:
-        - 10
-        - 9
-        - 8
-        - 7
-        - 6
-        - 5
-        - 4
-        - 3
-        - 2
-        - 1
-        - 0
-        default: 8
-        description: zoom resolution of the dataset
-        type: int
-    metadata:
-      project: global_hackathon
-      experiment_id: hackathon
-      source_id: Unified_Model
-      simulation_id: N2560_RAL3p3
   um_glm_n1280_GAL9:
     args:
       chunks: null
@@ -167,42 +132,12 @@ sources:
     metadata:
       project: global_hackathon
       experiment_id: hackathon
+      experiment_index: 1
       source_id: Unified_Model
       simulation_id: N1280_GAL9
-  um_glm_n1280_CoMA9:
-    args:
-      chunks: null
-      consolidated: true
-      urlpath: https://hackathon-o.s3-ext.jc.rl.ac.uk/sim-data/dev/v5/glm.n1280_CoMA9/um.{{ time }}.hp_z{{ zoom }}.zarr
-    driver: zarr
-    parameters:
-      time:
-        allowed:
-        - PT1H
-        - PT3H
-        default: PT1H
-        description: time resolution of the dataset
-        type: str
-      zoom:
-        allowed:
-        - 9
-        - 8
-        - 7
-        - 6
-        - 5
-        - 4
-        - 3
-        - 2
-        - 1
-        - 0
-        default: 8
-        description: zoom resolution of the dataset
-        type: int
-    metadata:
-      project: global_hackathon
-      experiment_id: hackathon
-      source_id: Unified_Model
-      simulation_id: N1280_CoMA9
+      region: glm
+      resolution: 10km
+      configuration: GAL9
   um_CTC_km4p4_RAL3P3_n1280_GAL9_nest:
     args:
       chunks: null
@@ -236,12 +171,16 @@ sources:
     metadata:
       project: global_hackathon
       experiment_id: hackathon
+      experiment_index: 1
       source_id: Unified_Model
       simulation_id: CTC_km4p4_RAL3P3_n1280_GAL9_nest
       geospatial_lon_min: 0.00
       geospatial_lon_max: 360.00
       geospatial_lat_min: -40.00
       geospatial_lat_max: 26.00
+      region: CTC
+      resolution: 4.4km
+      configuration: RAL3p3
   um_SAmer_km4p4_RAL3P3_n1280_GAL9_nest:
     args:
       chunks: null
@@ -275,12 +214,16 @@ sources:
     metadata:
       project: global_hackathon
       experiment_id: hackathon
+      experiment_index: 1
       source_id: Unified_Model
       simulation_id: SAmer_km4p4_RAL3P3_n1280_GAL9_nest
       geospatial_lon_min: 274.00
       geospatial_lon_max: 333.96
       geospatial_lat_min: -30.00
       geospatial_lat_max: 13.96
+      region: SAmer
+      resolution: 4.4km
+      configuration: RAL3p3
   um_Africa_km4p4_RAL3P3_n1280_GAL9_nest:
     args:
       chunks: null
@@ -314,12 +257,16 @@ sources:
     metadata:
       project: global_hackathon
       experiment_id: hackathon
+      experiment_index: 1
       source_id: Unified_Model
       simulation_id: Africa_km4p4_RAL3P3_n1280_GAL9_nest
       geospatial_lon_min: 340.00
       geospatial_lon_max: 53.96
       geospatial_lat_min: -40.00
       geospatial_lat_max: 25.96
+      region: Africa
+      resolution: 4.4km
+      configuration: RAL3p3
   um_SEA_km4p4_RAL3P3_n1280_GAL9_nest:
     args:
       chunks: null
@@ -353,9 +300,90 @@ sources:
     metadata:
       project: global_hackathon
       experiment_id: hackathon
+      experiment_index: 1
       source_id: Unified_Model
       simulation_id: SEA_km4p4_RAL3P3_n1280_GAL9_nest
       geospatial_lon_min: 90.00
       geospatial_lon_max: 153.96
       geospatial_lat_min: -18.00
       geospatial_lat_max: 25.96
+      region: SEA
+      resolution: 4.4km
+      configuration: RAL3p3
+  um_glm_n2560_RAL3p3:
+    args:
+      chunks: null
+      consolidated: true
+      urlpath: https://hackathon-o.s3-ext.jc.rl.ac.uk/sim-data/dev/v5/glm.n2560_RAL3p3/um.{{ time }}.hp_z{{ zoom }}.zarr
+    driver: zarr
+    parameters:
+      time:
+        allowed:
+        - PT1H
+        - PT3H
+        default: PT1H
+        description: time resolution of the dataset
+        type: str
+      zoom:
+        allowed:
+        - 10
+        - 9
+        - 8
+        - 7
+        - 6
+        - 5
+        - 4
+        - 3
+        - 2
+        - 1
+        - 0
+        default: 8
+        description: zoom resolution of the dataset
+        type: int
+    metadata:
+      project: global_hackathon
+      experiment_id: hackathon
+      experiment_index: 2
+      source_id: Unified_Model
+      simulation_id: N2560_RAL3p3
+      region: glm
+      resolution: 5km
+      configuration: RAL3p3
+  um_glm_n1280_CoMA9_TBv1p2:
+    args:
+      chunks: null
+      consolidated: true
+      urlpath: https://hackathon-o.s3-ext.jc.rl.ac.uk/sim-data/dev/v5/glm.n1280_CoMA9/um.{{ time }}.hp_z{{ zoom }}.zarr
+    driver: zarr
+    parameters:
+      time:
+        allowed:
+        - PT1H
+        - PT3H
+        default: PT1H
+        description: time resolution of the dataset
+        type: str
+      zoom:
+        allowed:
+        - 9
+        - 8
+        - 7
+        - 6
+        - 5
+        - 4
+        - 3
+        - 2
+        - 1
+        - 0
+        default: 8
+        description: zoom resolution of the dataset
+        type: int
+    metadata:
+      project: global_hackathon
+      experiment_id: hackathon
+      experiment_index: 3
+      source_id: Unified_Model
+      simulation_id: N1280_CoMA9_TBv1p2
+      region: glm
+      resolution: 10km
+      configuration: CoMA9


### PR DESCRIPTION
Also make the order consistent between the two catalogs (which makes for a less clear diff unfortunately).