### PR TITLE
Add IR_IMERG v1 to the online and UK catalogs (slightly different URLs)

### DIFF
--- a/UK/main.yaml
+++ b/UK/main.yaml
@@ -1,4 +1,9 @@
 sources:
+  IR_IMERG:
+    args:
+      consolidated: true
+      urlpath: http://hackathon-o.s3.jc.rl.ac.uk/obs-data/dev/v1/IR_IMERG_combined/IR_IMERG_combined_V07B.hp_z9.zarr
+    driver: zarr
   um_glm_n1280_GAL9:
     args:
       chunks: null

--- a/online/main.yaml
+++ b/online/main.yaml
@@ -26,6 +26,11 @@ sources:
       consolidated: true
       urlpath: https://swift.dkrz.de/v1/dkrz_41caca03ec414c2f95f52b23b775134f/reanalysis/v1/MERRA2_P1M_7.zarr
     driver: zarr
+  IR_IMERG:
+    args:
+      consolidated: true
+      urlpath: https://hackathon-o.s3-ext.jc.rl.ac.uk/obs-data/dev/v1/IR_IMERG_combined/IR_IMERG_combined_V07B.hp_z9.zarr
+    driver: zarr
   icon_ngc4008:
     args:
       chunks: null


### PR DESCRIPTION
First attempt at making healpix version of GPM IR Tb and IMERG Precip. Only zoom 9 currently available. Test with:

```python
import cartopy.crs as ccrs
import easygems.healpix as egh
import intake
import matplotlib as mpl
import matplotlib.pyplot as plt
import xarray as xr
mpl.rcParams['figure.dpi'] = 72

cat = intake.open_catalog('https://raw.githubusercontent.com/digital-earths-global-hackathon/catalog/refs/heads/add-healpix-IR-IMERG/catalog.yaml')['online']
ds = cat['IR_IMERG'].to_dask()
# time in ['2019-01-01 00:00', '2021-12-31 23:00']
time = '2019-11-01 02:00'
fig, (ax0, ax1) = plt.subplots(2, 1, figsize=(10, 8), subplot_kw={'projection': ccrs.Robinson(central_longitude=-137)})
def egh_plot(data, ax, **kwargs):
    ax.set_title(f'{data.name} [{data.attrs["units"]}]')
    ax.set_global()
    im = egh.healpix_show(data, ax=ax, **kwargs)
    plt.colorbar(im, ax=ax)
    ax.coastlines()

egh_plot(ds.precipitation.sel(time=time), ax=ax0, norm=mpl.colors.LogNorm(vmin=10e-2, vmax=30))
egh_plot(ds.Tb.sel(time=time), ax=ax1)
```
