### PR TITLE
index: add scrollbars and shadows to large summaries

### DIFF
--- a/scripts/templates/index.html
+++ b/scripts/templates/index.html
@@ -120,6 +120,51 @@
                 margin: 0;
                 margin-bottom: .2em;
             }
+
+            div.more {
+                max-height: 10em;
+                overflow: scroll;
+
+                --bgRGB: var(--bg-color);
+                --bg: var(--bg-color);
+                --bgTrans: transparent;
+
+                --shadow: color-mix(in srgb, var(--fg-color) 25%, transparent);
+
+                max-height: 200px;
+                overflow: auto;
+
+                background:
+                    /* Shadow Cover TOP */
+                    linear-gradient(
+                    var(--bg) 30%,
+                    var(--bgTrans)
+                    ) center top,
+
+                    /* Shadow Cover BOTTOM */
+                    linear-gradient(
+                    var(--bgTrans),
+                    var(--bg) 70%
+                    ) center bottom,
+
+                    /* Shadow TOP */
+                    radial-gradient(
+                    farthest-side at 50% 0,
+                    var(--shadow),
+                    rgba(0, 0, 0, 0)
+                    ) center top,
+
+                    /* Shadow BOTTOM */
+                    radial-gradient(
+                    farthest-side at 50% 100%,
+                    var(--shadow),
+                    rgba(0, 0, 0, 0)
+                    ) center bottom;
+
+                background-repeat: no-repeat;
+                background-size: 100% 40px, 100% 40px, 100% 14px, 100% 14px;
+                background-attachment: local, local, scroll, scroll;
+            }
         </style>
     </head>
     <body>
@@ -166,6 +211,7 @@
                 {% if mlds.metadata.title %}
                 <h4>{{ mlds.metadata.title }}</h4>
                 {% endif %}
+                <div class="more">
                 {% if mlds.metadata.summary %}
                 <div class="summary">
                 {{ mlds.metadata.summary | markdown }}
@@ -185,6 +231,7 @@
                     {% endfor %}
                 </ul>
                 {% endif %}
+                </div>
                 <div class="providers"><ul>{% for zone in sorted(mlds.raw) %}<li>{{ zone }}</li>{% endfor %}</ul></div>
                 <div class="zones"><ul>{% for zone in sorted(mlds.available_at) %}<li>{{ zone }}</li>{% endfor %}</ul></div>
             </li>


### PR DESCRIPTION
Some summaries have grown to considerable size. This is good, because they provide important descriptions of the model, but it also breaks the layout of the index page a bit.

This PR limits the vertical size of the summary and references section for each dataset in the index page, and adds scrollbards and a small shaddow to indicate there's more to find.