### PR TITLE
Icon online catalog updates

### DIFF
--- a/online/main.yaml
+++ b/online/main.yaml
@@ -87,6 +87,8 @@ sources:
         type: str
       zoom:
         allowed:
+        - 11
+        - 10
         - 9
         - 8
         - 7


### PR DESCRIPTION
Further extensions for icon-d3hp003 datasets: 
1. Adds z10 and z11 datasets for online access. 
2. Adds pt15m simulations for online access as well. 