### PR TITLE
Add SCREAM dataset from S3@DKRZ

### DIFF
--- a/online/main.yaml
+++ b/online/main.yaml
@@ -511,7 +511,7 @@ sources:
         default: 0
         description: zoom resolution of the dataset
         type: int
-  scream:
+  scream-dkrz:
     args:
       chunks: null
       consolidated: true
@@ -522,7 +522,7 @@ sources:
         allowed:
         - P1D
         - PT1H
-        - PT6H
+        - PT3H
         default: PT1H
         description: time resolution of the dataset
         type: str

--- a/online/main.yaml
+++ b/online/main.yaml
@@ -511,3 +511,35 @@ sources:
         default: 0
         description: zoom resolution of the dataset
         type: int
+  scream:
+    args:
+      chunks: null
+      consolidated: true
+      urlpath: https://s3.eu-dkrz-1.dkrz.cloud/wrcp-hackathon/data/SCREAM/scream_{{ time }}_z{{ zoom }}_v7.zarr
+    driver: zarr
+    parameters:
+      time:
+        allowed:
+        - P1D
+        - PT1H
+        - PT6H
+        default: PT1H
+        description: time resolution of the dataset
+        type: str
+      zoom:
+        allowed:
+        - 10
+        - 9
+        - 8
+        - 7
+        - 6
+        - 5
+        - 4
+        - 3
+        - 2
+        - 1
+        - 0
+        default: 2
+        description: zoom resolution of the dataset
+        type: int
+    # metadata is in the NERSC catalog

--- a/online/main.yaml
+++ b/online/main.yaml
@@ -542,4 +542,33 @@ sources:
         default: 2
         description: zoom resolution of the dataset
         type: int
+    metadata:
+      project: global_hackathon
+      experiment_id: dyamond3
+      source_id: SCREAM
+      simulation_id: cess-control.ne1024pg2_ne1024pg2.F2010-SCREAMv1.cess-oct2
+      time_start: 2019-08-01T00:00:00
+      time_end: 2020-09-01T00:00:00
+      title: SCREAM CESS experiment subset for Hamburg node
+      summary: |
+        Subset of what is available via Globus.
+        Each entry merges existing datasets as follows:
+         
+        scream_PT1H (Resolution 0-10):
+          * scream2D_hrly_pr_hp*_v7
+          * scream2D_hrly_rlut_hp*_v7
+        scream_PT3H (Resolution 0-8): 
+          * scream2D_ne120_all_hp*_v7
+          * scream3D_ne120_hus_hp*_v7
+        scream_P1D (Resolution 0-8):
+          * scream_lnd_mrso_hp*_v4
+          * scream_lnd_swe_hp*_v4
+
+      references: https://github.com/digital-earths-global-hackathon/hk25/blob/main/content/models/scream.md
+      reprocessed_by: Manuel Reis
+      creator_name: Andrew Gettelman & Manuel Reis
+      creator_email:
+       - andrew.gettelman@pnnl.gov
+       - reis@dkrz.de
+      institution: U.S. Department of Energy, E3SM Project
     # metadata is in the NERSC catalog


### PR DESCRIPTION
As requested by @flo-hackathon I've merged what was possible from `/work/bm1235/k202134/SCREAM/`. Rechunked lower resolutions, and uploaded to S3.

| New name | Contains |
| ---- | ---- |
`scream_PT1H_z0_v7.zarr` | `scream2D_hrly_pr_hp0_v7` + `scream2D_hrly_rlut_hp0_v7`
`scream_PT3H_z0_v7.zarr` | `scream2D_ne120_all_hp0_v7` + `scream3D_ne120_hus_hp0_v7`
`scream_P1D_z0_v7.zarr` | `scream_lnd_mrso_hp0_v4` + `scream_lnd_swe_hp0_v4`

> Note: `P1D` has a prefix `v7` but the original datasets have `v4`
