### PR TITLE
Add a static file to the UM global sims: orog/surface_land_frac

### DIFF
--- a/UK/main.yaml
+++ b/UK/main.yaml
@@ -8,14 +8,15 @@ sources:
     args:
       chunks: null
       consolidated: true
-      urlpath: http://hackathon-o.s3.jc.rl.ac.uk/sim-data/dev/v5/glm.n1280_GAL9_nest/um.{{ time }}.hp_z{{ zoom }}.zarr
+      urlpath:
+        - http://hackathon-o.s3.jc.rl.ac.uk/sim-data/dev/v5/glm.n1280_GAL9_nest/um.{{ time }}.hp_z{{ zoom }}.zarr
+        - http://hackathon-o.s3.jc.rl.ac.uk/sim-data/dev/v5/glm.n1280_GAL9_nest/um.static.hp_z{{ zoom }}.zarr
     driver: zarr
     parameters:
       time:
         allowed:
         - PT1H
         - PT3H
-        - static
         default: PT1H
         description: time resolution of the dataset
         type: str
@@ -304,14 +305,15 @@ sources:
     args:
       chunks: null
       consolidated: true
-      urlpath: http://hackathon-o.s3.jc.rl.ac.uk/sim-data/dev/v5/glm.n2560_RAL3p3/um.{{ time }}.hp_z{{ zoom }}.zarr
+      urlpath:
+        - http://hackathon-o.s3.jc.rl.ac.uk/sim-data/dev/v5/glm.n2560_RAL3p3/um.{{ time }}.hp_z{{ zoom }}.zarr
+        - http://hackathon-o.s3.jc.rl.ac.uk/sim-data/dev/v5/glm.n2560_RAL3p3/um.static.hp_z{{ zoom }}.zarr
     driver: zarr
     parameters:
       time:
         allowed:
         - PT1H
         - PT3H
-        - static
         default: PT1H
         description: time resolution of the dataset
         type: str
@@ -362,14 +364,15 @@ sources:
     args:
       chunks: null
       consolidated: true
-      urlpath: http://hackathon-o.s3.jc.rl.ac.uk/sim-data/dev/v5/glm.n1280_CoMA9/um.{{ time }}.hp_z{{ zoom }}.zarr
+      urlpath:
+        - http://hackathon-o.s3.jc.rl.ac.uk/sim-data/dev/v5/glm.n1280_CoMA9/um.{{ time }}.hp_z{{ zoom }}.zarr
+        - http://hackathon-o.s3.jc.rl.ac.uk/sim-data/dev/v5/glm.n1280_CoMA9/um.static.hp_z{{ zoom }}.zarr
     driver: zarr
     parameters:
       time:
         allowed:
         - PT1H
         - PT3H
-        - static
         default: PT1H
         description: time resolution of the dataset
         type: str

--- a/UK/main.yaml
+++ b/UK/main.yaml
@@ -15,6 +15,7 @@ sources:
         allowed:
         - PT1H
         - PT3H
+        - static
         default: PT1H
         description: time resolution of the dataset
         type: str
@@ -310,6 +311,7 @@ sources:
         allowed:
         - PT1H
         - PT3H
+        - static
         default: PT1H
         description: time resolution of the dataset
         type: str
@@ -367,6 +369,7 @@ sources:
         allowed:
         - PT1H
         - PT3H
+        - static
         default: PT1H
         description: time resolution of the dataset
         type: str

--- a/online/main.yaml
+++ b/online/main.yaml
@@ -267,14 +267,15 @@ sources:
     args:
       chunks: null
       consolidated: true
-      urlpath: https://hackathon-o.s3-ext.jc.rl.ac.uk/sim-data/dev/v5/glm.n1280_GAL9_nest/um.{{ time }}.hp_z{{ zoom }}.zarr
+      urlpath:
+        - https://hackathon-o.s3-ext.jc.rl.ac.uk/sim-data/dev/v5/glm.n1280_GAL9_nest/um.{{ time }}.hp_z{{ zoom }}.zarr
+        - http://hackathon-o.s3.jc.rl.ac.uk/sim-data/dev/v5/glm.n1280_GAL9_nest/um.static.hp_z{{ zoom }}.zarr
     driver: zarr
     parameters:
       time:
         allowed:
         - PT1H
         - PT3H
-        - static
         default: PT1H
         description: time resolution of the dataset
         type: str
@@ -422,14 +423,15 @@ sources:
     args:
       chunks: null
       consolidated: true
-      urlpath: https://hackathon-o.s3-ext.jc.rl.ac.uk/sim-data/dev/v5/glm.n2560_RAL3p3/um.{{ time }}.hp_z{{ zoom }}.zarr
+      urlpath:
+        - https://hackathon-o.s3-ext.jc.rl.ac.uk/sim-data/dev/v5/glm.n2560_RAL3p3/um.{{ time }}.hp_z{{ zoom }}.zarr
+        - https://hackathon-o.s3-ext.jc.rl.ac.uk/sim-data/dev/v5/glm.n2560_RAL3p3/um.static.hp_z{{ zoom }}.zarr
     driver: zarr
     parameters:
       time:
         allowed:
         - PT1H
         - PT3H
-        - static
         default: PT1H
         description: time resolution of the dataset
         type: str
@@ -454,14 +456,15 @@ sources:
     args:
       chunks: null
       consolidated: true
-      urlpath: https://hackathon-o.s3-ext.jc.rl.ac.uk/sim-data/dev/v5/glm.n1280_CoMA9/um.{{ time }}.hp_z{{ zoom }}.zarr
+      urlpath:
+        - https://hackathon-o.s3-ext.jc.rl.ac.uk/sim-data/dev/v5/glm.n1280_CoMA9/um.{{ time }}.hp_z{{ zoom }}.zarr
+        - https://hackathon-o.s3-ext.jc.rl.ac.uk/sim-data/dev/v5/glm.n1280_CoMA9/um.static.hp_z{{ zoom }}.zarr
     driver: zarr
     parameters:
       time:
         allowed:
         - PT1H
         - PT3H
-        - static
         default: PT1H
         description: time resolution of the dataset
         type: str

--- a/online/main.yaml
+++ b/online/main.yaml
@@ -274,6 +274,7 @@ sources:
         allowed:
         - PT1H
         - PT3H
+        - static
         default: PT1H
         description: time resolution of the dataset
         type: str
@@ -428,6 +429,7 @@ sources:
         allowed:
         - PT1H
         - PT3H
+        - static
         default: PT1H
         description: time resolution of the dataset
         type: str
@@ -459,6 +461,7 @@ sources:
         allowed:
         - PT1H
         - PT3H
+        - static
         default: PT1H
         description: time resolution of the dataset
         type: str


### PR DESCRIPTION
I've created a separate global orog/land_surface_frac dataset - this catalog new parameter value `static` exposes these to users. Not ideal but see justification below.

@andrewgettelman this may be useful for the UM data you have locally - you could either `rclone` this over or just use the online version (it's very small and I believe it should be automatically added to your catalog through the merging magic).

**Justification:** After discussion with @d70-t, I tried to get orog/surface_land_frac in the main 2D/3D datasets, but it took a really long time to write a tiny amount of data. I suspect it was scanning the entire zarr store when it was trying to append. Also, in experimentation, I tried `ds_static.to_zarr(existing_store, mode='w')`. This was a bad idea. It deleted large amounts of the 2D data before I realized, forcing me to rebuild. The original command also overwrote the metadata for one of the stores I tried it on. With hindsight I obviously would have added from the outset, and with more time I could have added to existing stores.