### PR TITLE
Fix bug in mpas_dyamond3 filename

### DIFF
--- a/NCAR/main.yaml
+++ b/NCAR/main.yaml
@@ -3,7 +3,7 @@ sources:
     args:
       chunks: null
       consolidated: true
-      urlpath: /glade/derecho/scratch/digital-earths-hackathon/mpas_DYAMOND3/{{time}}/DYAMOND_diag_{{time}}_to_hp{{zoom}}.zarr
+      urlpath: /glade/derecho/scratch/digital-earths-hackathon/mpas_DYAMOND3/{{time}}/DYAMOND3_diag_{{time}}_to_hp{{zoom}}.zarr
     driver: zarr
     parameters:
       time:


### PR DESCRIPTION
Found a bug in the mpas_dyamond3 filename specification in the NCAR catalog. Filenames start with "DYAMOND3_diag_" (catalog had "DYAMOND_diag": no "3"). Corrected. You can merge this when you see it... Thanks!

Tested this correction and it loads fine.