### PR TITLE
mpas_dyamond: use ISO durations for time

### DIFF
--- a/NCAR/main.yaml
+++ b/NCAR/main.yaml
@@ -3,16 +3,19 @@ sources:
     args:
       chunks: null
       consolidated: true
-      urlpath: /glade/derecho/scratch/digital-earths-hackathon/mpas_DYAMOND3/{{time}}/DYAMOND3_*_{{time}}_to_hp{{zoom}}.zarr
+      urlpath: >
+        {% with time_map = {'PT15M': '15min', 'PT1H': '1hr', 'PT3H': '3hr', 'PT6H': '6hr'} -%}
+        /glade/derecho/scratch/digital-earths-hackathon/mpas_DYAMOND3/{{time_map[time]}}/DYAMOND3_*_{{time_map[time]}}_to_hp{{zoom}}.zarr
+        {%- endwith %}
     driver: zarr
     parameters:
       time:
         allowed:
-        - 30min
-        - 1hr
-        - 3hr
-        - 6hr
-        default: 1hr
+        - PT30M
+        - PT1H
+        - PT3H
+        - PT6H
+        default: PT1H
         description: temporal resolution of the dataset
         type: str
       zoom:
@@ -54,13 +57,16 @@ sources:
     args:
       chunks: null
       consolidated: true
-      urlpath: /glade/derecho/scratch/digital-earths-hackathon/mpas_DYAMOND1/{{time}}/DYAMOND1_diag_{{time}}_to_hp{{zoom}}.zarr
+      urlpath: >
+        {% with time_map = {'PT15M': '15min'} -%}
+        /glade/derecho/scratch/digital-earths-hackathon/mpas_DYAMOND1/{{time_map[time]}}/DYAMOND1_diag_{{time_map[time]}}_to_hp{{zoom}}.zarr
+        {%- endwith %}
     driver: zarr
     parameters:
       time:
         allowed:
-        - 15min
-        default: 15min
+        - PT15M
+        default: PT15M
         description: temporal resolution of the dataset
         type: str
       zoom:


### PR DESCRIPTION
This is a follow up on #64.
The change will make the catalog use ISO durations as `time` keys consistently without the need to change anything on the filesytem level. As I don't have access to the NCAR node, I'm not able to test if this actually opens the file, but I've checked the generated filenames, and we have already similar working examples.