### PR TITLE
Fix broken URL for external (to JASMIN) users.

### DIFF
--- a/online/main.yaml
+++ b/online/main.yaml
@@ -409,7 +409,7 @@ sources:
       consolidated: true
       urlpath:
         - https://hackathon-o.s3-ext.jc.rl.ac.uk/sim-data/dev/v5/glm.n1280_GAL9_nest/um.{{ time }}.hp_z{{ zoom }}.zarr
-        - http://hackathon-o.s3.jc.rl.ac.uk/sim-data/dev/v5/glm.n1280_GAL9_nest/um.static.hp_z{{ zoom }}.zarr
+        - https://hackathon-o.s3-ext.jc.rl.ac.uk/sim-data/dev/v5/glm.n1280_GAL9_nest/um.static.hp_z{{ zoom }}.zarr
     driver: zarr
     parameters:
       time:


### PR DESCRIPTION
URL should be `https` and use `s3-ext` instead of `s3`.