### PR TITLE
Opened up NICAM z8-9 for NERSC

### DIFF
--- a/NERSC/main.yaml
+++ b/NERSC/main.yaml
@@ -350,8 +350,8 @@ sources:
         type: str
       zoom:
         allowed:
-#        - 9
-#        - 8
+        - 9
+        - 8
         - 7
         - 6
         - 5


### PR DESCRIPTION
We now have zoom 8 and (some) zoom 9 data at NERSC, so minor catalog update to allow access to them....