### PR TITLE
NCAR: Fix the SCREAM data changed directory failures

### DIFF
--- a/NCAR/main.yaml
+++ b/NCAR/main.yaml
@@ -151,7 +151,7 @@ sources:
     args:
       chunks: null
       consolidated: true
-      urlpath: /glade/derecho/scratch/digital-earths-hackathon/e3sm/scream2D_hrly_*_hp{{ zoom }}_v7.zarr
+      urlpath: /glade/derecho/scratch/digital-earths-hackathon/e3sm/scream-cess-healpix/scream2D_hrly_*_hp{{ zoom }}_v7.zarr
     driver: zarr
     parameters:
       zoom:
@@ -175,7 +175,7 @@ sources:
     args:
       chunks: null
       consolidated: true
-      urlpath: /glade/derecho/scratch/digital-earths-hackathon/e3sm/scream*_ne120_*_hp{{ zoom }}_v7.zarr
+      urlpath: /glade/derecho/scratch/digital-earths-hackathon/e3sm/scream-cess-healpix/scream*_ne120_*_hp{{ zoom }}_v7.zarr
     driver: zarr
     parameters:
       zoom:


### PR DESCRIPTION
Turns out that the directory to the SCREAM data on NCAR's Glade was recently changed but never reflected in the catalog. This fixes it.