### PR TITLE
Deactivate NICAM PT1H

### DIFF
--- a/NERSC/main.yaml
+++ b/NERSC/main.yaml
@@ -342,7 +342,7 @@ sources:
     parameters:
       time:
         allowed:
-        - PT1H
+#        - PT1H
         - PT3H
         - PT6H
         default: PT3H


### PR DESCRIPTION
Removing NICAM PT1H as allowed from local NERSC catalog (local data is not working).  Responds to issue #82 