### PR TITLE
Added new zoom levels for IR_IMERG.

### DIFF
--- a/NERSC/main.yaml
+++ b/NERSC/main.yaml
@@ -217,6 +217,15 @@ sources:
       zoom:
         allowed:
         - 9
+        - 8
+        - 7
+        - 6
+        - 5
+        - 4
+        - 3
+        - 2
+        - 1
+        - 0
         default: 9
         description: zoom resolution of the dataset
         type: int


### PR DESCRIPTION
Hi @andrewgettelman, I reprocessed the IMERG healpix data and replaced the copy on NERSC. It includes:
1. Removing the 30min time stamps to make the dataset hourly.
2. Adding lower zoom levels.

I tested the local catalog file and can read the data.  I talked to Mark and he will likely transfer the data via Globus to UK and update their catalog accordingly.