### PR TITLE
Uncommented um_glm_n2560_RAL3p3 in the catalog.

### DIFF
--- a/NERSC/main.yaml
+++ b/NERSC/main.yaml
@@ -272,36 +272,36 @@ sources:
         type: int
     # metadata is in the EU Catalog
 
-  # um_glm_n2560_RAL3p3:
-  #   args:
-  #     chunks: null
-  #     consolidated: true
-  #     urlpath: /global/cfs/cdirs/m4581/gsharing/hackathon/UM/glm.n2560_RAL3p3/data.healpix.{{ time }}.z{{ zoom }}.zarr
-  #   driver: zarr
-  #   parameters:
-  #     time:
-  #       allowed:
-  #       - PT1H
-  #       - PT3H
-  #       default: PT1H
-  #       description: time resolution of the dataset
-  #       type: str
-  #     zoom:
-  #       allowed:
-  #       - 10
-  #       - 9
-  #       - 8
-  #       - 7
-  #       - 6
-  #       - 5
-  #       - 4
-  #       - 3
-  #       - 2
-  #       - 1
-  #       default: 8
-  #       description: zoom resolution of the dataset
-  #       type: int
-  #   # metadata is in the UK catalog
+  um_glm_n2560_RAL3p3:
+    args:
+      chunks: null
+      consolidated: true
+      urlpath: /global/cfs/cdirs/m4581/gsharing/hackathon/UM/glm.n2560_RAL3p3/data.healpix.{{ time }}.z{{ zoom }}.zarr
+    driver: zarr
+    parameters:
+      time:
+        allowed:
+        - PT1H
+        - PT3H
+        default: PT1H
+        description: time resolution of the dataset
+        type: str
+      zoom:
+        allowed:
+        - 10
+        - 9
+        - 8
+        - 7
+        - 6
+        - 5
+        - 4
+        - 3
+        - 2
+        - 1
+        default: 8
+        description: zoom resolution of the dataset
+        type: int
+    # metadata is in the UK catalog
 
   wrf_samerica:
     args:


### PR DESCRIPTION
Added **um_glm_n2560_RAL3p3** to local NERSC catalog.