### PR TITLE
Added PT1H to nicam_gl11 in NERSC catalog.

### DIFF
--- a/NERSC/main.yaml
+++ b/NERSC/main.yaml
@@ -351,7 +351,7 @@ sources:
     parameters:
       time:
         allowed:
-#        - PT1H
+        - PT1H
         - PT3H
         - PT6H
         default: PT3H


### PR DESCRIPTION
Downloaded nicam_gl11 PT1H 2D data to NERSC.

Tested the local catalog and confirmed the PT1H can be loaded.