### PR TITLE
Patch bucket name for waterpark links

### DIFF
--- a/online/main.yaml
+++ b/online/main.yaml
@@ -47,7 +47,7 @@ sources:
   CERES_EBAF:
     args: 
       consolidated: true
-      urlpath: https://s3.waterpark.dkrz.de/wcrp-hackathon/CERES/CERES_EBAF-TOA_Ed4.2.1_hp{{ zoom }}.zarr
+      urlpath: https://s3.waterpark.dkrz.de/misc/wcrp-hackathon/CERES/CERES_EBAF-TOA_Ed4.2.1_hp{{ zoom }}.zarr
     driver: zarr
     parameters:
       zoom:
@@ -59,7 +59,7 @@ sources:
     args:
       chunks: null
       consolidated: true
-      urlpath: https://s3.waterpark.dkrz.de/wcrp-hackathon/ICON/rechunked_ngc4008/ngc4008_{{ time }}_{{ zoom }}.zarr
+      urlpath: https://s3.waterpark.dkrz.de/misc/wcrp-hackathon/ICON/rechunked_ngc4008/ngc4008_{{ time }}_{{ zoom }}.zarr
     driver: zarr
     parameters:
       time:
@@ -117,7 +117,7 @@ sources:
     args:
       chunks: null
       consolidated: true
-      urlpath: https://s3.waterpark.dkrz.de/wcrp-hackathon/ICON/d3hp003.zarr/{{ time }}_{{ time_method }}_z{{ zoom }}_atm
+      urlpath: https://s3.waterpark.dkrz.de/misc/wcrp-hackathon/ICON/d3hp003.zarr/{{ time }}_{{ time_method }}_z{{ zoom }}_atm
     driver: zarr
     parameters:
       time:
@@ -199,7 +199,7 @@ sources:
     args:
       chunks: null
       consolidated: true
-      urlpath: https://s3.waterpark.dkrz.de/wcrp-hackathon/ICON/d3hp003feb.zarr/{{ time }}_{{ time_method }}_z{{ zoom }}_atm
+      urlpath: https://s3.waterpark.dkrz.de/misc/wcrp-hackathon/ICON/d3hp003feb.zarr/{{ time }}_{{ time_method }}_z{{ zoom }}_atm
     driver: zarr
     description: Atmosphere-only simulation at 2.5 km resolution
     parameters:
@@ -261,7 +261,7 @@ sources:
     args:
       chunks: null
       consolidated: true
-      urlpath: https://s3.waterpark.dkrz.de/wcrp-hackathon/ICON/d3hp003aug.zarr/{{ time }}_{{ time_method }}_z{{ zoom }}_atm
+      urlpath: https://s3.waterpark.dkrz.de/misc/wcrp-hackathon/ICON/d3hp003aug.zarr/{{ time }}_{{ time_method }}_z{{ zoom }}_atm
     driver: zarr
     description: Atmosphere-only simulation at 2.5 km resolution
     parameters:
@@ -814,7 +814,7 @@ sources:
     args:
       chunks: null
       consolidated: true
-      urlpath: https://s3.waterpark.dkrz.de/wcrp-hackathon/SCREAM/scream_{{ time }}_z{{ zoom }}_v7.zarr
+      urlpath: https://s3.waterpark.dkrz.de/misc/wcrp-hackathon/SCREAM/scream_{{ time }}_z{{ zoom }}_v7.zarr
     driver: zarr
     parameters:
       time:
@@ -875,7 +875,7 @@ sources:
     args:
       chunks: null
       consolidated: true
-      urlpath: https://s3.waterpark.dkrz.de/wcrp-hackathon/CAS-ESM2/CAS-ESM2_10km_nocumulus_{{ time }}_z{{ zoom }}.zarr
+      urlpath: https://s3.waterpark.dkrz.de/misc/wcrp-hackathon/CAS-ESM2/CAS-ESM2_10km_nocumulus_{{ time }}_z{{ zoom }}.zarr
     driver: zarr
     parameters:
       time:
@@ -906,14 +906,14 @@ sources:
     args:
       chunks: null
       consolidated: true
-      urlpath: https://s3.waterpark.dkrz.de/wcrp-hackathon/ICON/mcstracking/mcs_mask_hp9_20200102.0000_20201231.2330.zarr
+      urlpath: https://s3.waterpark.dkrz.de/misc/wcrp-hackathon/ICON/mcstracking/mcs_mask_hp9_20200102.0000_20201231.2330.zarr
     driver: zarr
     description: Tracking for ICON d3hp003
   arp-gem-1p3km:
     args:
       chunks: null
       consolidated: true
-      urlpath: https://s3.waterpark.dkrz.de/wcrp-hackathon/ARP-GEM/ARPGEM2_1p3km_{{ time }}_inst_z{{ zoom }}.zarr
+      urlpath: https://s3.waterpark.dkrz.de/misc/wcrp-hackathon/ARP-GEM/ARPGEM2_1p3km_{{ time }}_inst_z{{ zoom }}.zarr
     driver: zarr
     parameters:
       time:
@@ -940,7 +940,7 @@ sources:
     args:
       chunks: null
       consolidated: true
-      urlpath: https://s3.waterpark.dkrz.de/wcrp-hackathon/ARP-GEM/ARPGEM2_2p6km_{{ time }}_inst_z{{ zoom }}.zarr
+      urlpath: https://s3.waterpark.dkrz.de/misc/wcrp-hackathon/ARP-GEM/ARPGEM2_2p6km_{{ time }}_inst_z{{ zoom }}.zarr
     driver: zarr
     parameters:
       time:


### PR DESCRIPTION
Updating bucket + prefix structure. To avoid some issues in future with cases such as this one, a common bucket  (`misc`) for all those was a requirement.